### PR TITLE
build: add AppImage build config and GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,63 @@
+name: Build
+
+on:
+  [push, pull_request]
+
+jobs:
+  build-windows:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16
+        cache: 'yarn'
+    - name: Install deps
+      run: yarn
+    - name: Build windows nsis installer
+      run: npm run nsis
+    - name: Build windows nsis installer (x86/ia32)
+      run: npm run nsis-ia32
+    - name: Build windows 7zip protable version
+      run: npm run 7zip
+    - name: Build windows 7zip protable version (x86/ia32)
+      run: npm run 7zip-ia32
+    - uses: actions/upload-artifact@v2
+      with:
+        path: |
+          packaged/wnr-*-Setup-64.exe
+          packaged/wnr-*-Setup-32.exe
+          packaged/wnr-*-Win-64.7z
+          packaged/wnr-*-Win-32.7z
+
+  build-macos:
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16
+        cache: 'yarn'
+    - name: Install deps
+      run: yarn
+    - name: Build macos version
+      run: npm run mac
+    - uses: actions/upload-artifact@v2
+      with:
+        path: packaged/wnr-*-MacOS.dmg
+
+  build-linux:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16
+        cache: 'yarn'
+    - name: Install deps
+      run: yarn
+    - name: Build AppImage
+      run: npm run appimage
+    - uses: actions/upload-artifact@v2
+      with:
+        path: packaged/wnr-*-Linux.AppImage

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ yarn 7zip-ia32 # windows 7zip portable version (x86/ia32)
 yarn mac # macos
 
 yarn linux # linux
+
+yarn appimage # linux AppImage
 ```
 
 Please note that:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -136,6 +136,8 @@ yarn 7zip-ia32 # Windows平台7z便携版打包（32位）
 yarn mac # macOS版本打包
 
 yarn linux # Linux版本打包
+
+yarn appimage # linux AppImage打包
 ```
 
 请注意：

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -134,6 +134,8 @@ yarn 7zip-ia32 # Windows平台7z便攜版打包（32位）
 yarn mac # macOS版本打包
 
 yarn linux # Linux版本打包
+
+yarn appimage # linux AppImage打包
 ```
 
 請注意：

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"7zip-ia32": "cross-env NODE_ENV=portable node ./res/builder/win-zip-ia32.js",
 		"mac": "cross-env NODE_ENV=production node ./res/builder/mac.js",
 		"linux": "cross-env NODE_ENV=production node ./res/builder/linux.js",
+		"appimage": "cross-env NODE_ENV=production node ./res/builder/appimage.js",
 		"dir": "cross-env NODE_ENV=production node ./res/builder/dir_test.js",
 		"ms-store": "cross-env NODE_ENV=msstore node ./res/builder/dir_test.js"
 	},

--- a/res/builder/appimage.js
+++ b/res/builder/appimage.js
@@ -1,0 +1,38 @@
+const builder = require('electron-builder')
+const Platform = builder.Platform
+
+require("./env_commit")
+
+const config = {
+    "directories": {
+        "output": "packaged/"
+    },
+    "linux": {
+        "asarUnpack": [
+            "./node_modules/node-notifier/vendor/**"
+        ],
+        "target": [
+            "AppImage"
+        ],
+        "icon": "res/icons/wnrIcon.png",
+        "files": [
+            "**/*",
+            //! to exclude
+            "!res/icons/*Mac*",
+            "!res/icons/*Win*",
+            "!res/icons/*.psd",
+            "!./node_modules/node-notifier/vendor/snoreToast/**"
+        ]
+    }
+}
+
+builder.build({
+    targets: Platform.LINUX.createTarget(),
+    config,
+})
+    .then(m => {
+        console.log(m)
+    })
+    .catch(e => {
+        console.error(e)
+    })

--- a/res/builder/appimage.js
+++ b/res/builder/appimage.js
@@ -22,8 +22,13 @@ const config = {
             "!res/icons/*Win*",
             "!res/icons/*.psd",
             "!./node_modules/node-notifier/vendor/snoreToast/**"
-        ]
-    }
+        ],
+        "category": "Utility"
+    },
+    "appImage": {
+        "artifactName": "${productName}-${version}-Linux.${ext}"
+    },
+    "publish": null
 }
 
 builder.build({

--- a/res/builder/dir_test.js
+++ b/res/builder/dir_test.js
@@ -41,6 +41,7 @@ const config = {
             "!./node_modules/node-notifier/vendor/snoreToast/**"
         ]
     },
+    "publish": null
 }
 
 builder.build({

--- a/res/builder/linux.js
+++ b/res/builder/linux.js
@@ -22,8 +22,10 @@ const config = {
             "!res/icons/*Win*",
             "!res/icons/*.psd",
             "!./node_modules/node-notifier/vendor/snoreToast/**"
-        ]
-    }
+        ],
+        "category": "Utility"
+    },
+    "publish": null
 }
 
 builder.build({

--- a/res/builder/mac.js
+++ b/res/builder/mac.js
@@ -29,7 +29,8 @@ const config = {
         "icon": "res/icons/iconMac.icns",
         "backgroundColor": "#fefefe",
         "artifactName": "${productName}-${version}-MacOS.${ext}"
-    }
+    },
+    "publish": null
 }
 
 builder.build({

--- a/res/builder/nsis-ia32.js
+++ b/res/builder/nsis-ia32.js
@@ -41,7 +41,8 @@ const config = {
         "installerSidebar": "res/builder/nsisResources/installerSidebar.bmp",
         "artifactName": "${productName}-${version}-Setup-32.${ext}",
         "allowToChangeInstallationDirectory": true
-    }
+    },
+    "publish": null
 }
 
 builder.build({

--- a/res/builder/nsis.js
+++ b/res/builder/nsis.js
@@ -38,7 +38,8 @@ const config = {
         "installerSidebar": "res/builder/nsisResources/installerSidebar.bmp",
         "artifactName": "${productName}-${version}-Setup-64.${ext}",
         "allowToChangeInstallationDirectory": true
-    }
+    },
+    "publish": null
 }
 
 builder.build({

--- a/res/builder/win-zip-ia32.js
+++ b/res/builder/win-zip-ia32.js
@@ -27,7 +27,8 @@ const config = {
             "!designs/**"
         ],
         "artifactName": "${productName}-${version}-Win-32.${ext}"
-    }
+    },
+    "publish": null
 }
 
 builder.build({

--- a/res/builder/win-zip.js
+++ b/res/builder/win-zip.js
@@ -24,7 +24,8 @@ const config = {
             "!designs/**"
         ],
         "artifactName": "${productName}-${version}-Win-64.${ext}"
-    }
+    },
+    "publish": null
 }
 
 builder.build({


### PR DESCRIPTION
GitHub Actions can help you build wnr and upload the artifacts every time when you push a new commit to the repo or to a pull request.

AppImage is a common app format widely used in various GNU/Linux distros which packs the program into only one executable.

`"publish": null` is useful to disable the unnecessary and annoying publishing functionality provided by the electron-builder (which is enabled by default when building using GitHub Actions).