### PR TITLE
Disable the dragging operation for buttons in floating window

### DIFF
--- a/floating.html
+++ b/floating.html
@@ -26,28 +26,28 @@
             </div>
             <div id="floating-hover" onmouseover="hover()" onmouseleave="unhover()" ontouchstart="semihover()">
                 <div class="small" id="floating-stopper">
-                    <a id="stopper" href="javascript:stopper()" class="text-muted">
+                    <a id="stopper" href="javascript:stopper()" class="text-muted" draggable="false">
                         <i class="iconfont icon-pause"></i>
                     </a>
                     <div id="stopper-spacing"><br /><br /></div>
                 </div>
                 <div class="extreme-small" id="floating-recover">
-                    <a href="javascript:recover()" class="text-muted text-left">
+                    <a href="javascript:recover()" class="text-muted text-left" draggable="false">
                         <i class="iconfont icon-expand-arrows-alt" id="recover"></i>
                     </a>
                 </div>
                 <div class="extreme-small" id="floating-close">
-                    <a href="javascript:recover()" class="text-muted text-right">
+                    <a href="javascript:recover()" class="text-muted text-right" draggable="false">
                         <i class="iconfont icon-close" id="exit"></i>
                     </a>
                 </div>
                 <div class="extreme-small" id="floating-back">
-                    <a href="javascript:backer()" class="text-muted text-left">
+                    <a href="javascript:backer()" class="text-muted text-left" draggable="false">
                         <i class="iconfont icon-previous" id="back-index"></i>
                     </a>
                 </div>
                 <div class="extreme-small" id="floating-skipper">
-                    <a href="javascript:skipper()" class="text-muted text-right">
+                    <a href="javascript:skipper()" class="text-muted text-right" draggable="false">
                         <i class="iconfont icon-fastforward" id="skipper"></i>
                     </a>
                 </div>


### PR DESCRIPTION
In the floating window (i.e. the mini mode), the buttons are all draggable.
The dragging operation on these buttons may cause some UI bugs.