### PR TITLE
Add preset time dropdowns for work, rest, and loop durations

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,20 @@
             <div class="align-content-center">
                 <input name="rest-time-onlyrest" id="rest-time-onlyrest" type="text" onkeyup="allSet()"
                        class="onlyRest lead text-center" required />
+                <div class="dropdown d-inline time-preset-dropdown">
+                    <a class="dropdown-toggle" href="#" role="button" id="rest-time-onlyrest-presets-dropdown"
+                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <i class="iconfont icon-caret-down onlyRest"></i>
+                    </a>
+                    <div class="dropdown-menu" aria-labelledby="rest-time-onlyrest-presets-dropdown">
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 3)">3 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 5)">5 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 10)">10 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 15)">15 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 20)">20 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 30)">30 <script>document.write(i18n.__('min'))</script></a>
+                    </div>
+                </div>
                 <br /><br />
                 <center>
                     <input id="focus-rest-set-onlyrest" type="checkbox" onchange="focusNotifier()" />
@@ -238,6 +252,21 @@
             <div class="align-content-center">
                 <input name="work-time" id="work-time" type="text" onkeyup="allSet()" class="work lead" autofocus
                        required />
+                <div class="dropdown d-inline time-preset-dropdown">
+                    <a class="dropdown-toggle" href="#" role="button" id="work-time-presets-dropdown"
+                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <i class="iconfont icon-caret-down work"></i>
+                    </a>
+                    <div class="dropdown-menu" aria-labelledby="work-time-presets-dropdown">
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 10)">10 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 20)">20 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 30)">30 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 45)">45 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 60)">60 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 90)">90 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 120)">120 <script>document.write(i18n.__('min'))</script></a>
+                    </div>
+                </div>
                 <input id="focus-work-set" type="checkbox" onchange="focusNotifier()" />
                 <span class="focuser extreme-small work">
                     <script>document.write(i18n.__('focus-mode-part-1') + "<br />" + i18n.__('focus-mode-part-2'))</script>
@@ -246,6 +275,20 @@
             <br />
             <div class="align-content-center">
                 <input name="rest-time" id="rest-time" type="text" onkeyup="allSet()" class="rest lead" required />
+                <div class="dropdown d-inline time-preset-dropdown">
+                    <a class="dropdown-toggle" href="#" role="button" id="rest-time-presets-dropdown"
+                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <i class="iconfont icon-caret-down rest"></i>
+                    </a>
+                    <div class="dropdown-menu" aria-labelledby="rest-time-presets-dropdown">
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 3)">3 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 5)">5 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 10)">10 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 15)">15 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 20)">20 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 30)">30 <script>document.write(i18n.__('min'))</script></a>
+                    </div>
+                </div>
                 <input id="focus-rest-set" type="checkbox" onchange="focusNotifier()" />
                 <span class="focuser extreme-small rest">
                     <script>document.write(i18n.__('focus-mode-part-1') + "<br />" + i18n.__('focus-mode-part-2'))</script>
@@ -254,6 +297,19 @@
             <br />
             <div class="align-content-center">
                 <input name="loop" id="loop" type="text" onkeyup="allSet()" class="small text-muted" required />
+                <div class="dropdown d-inline time-preset-dropdown">
+                    <a class="dropdown-toggle" href="#" role="button" id="loop-presets-dropdown"
+                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <i class="iconfont icon-caret-down text-muted"></i>
+                    </a>
+                    <div class="dropdown-menu" aria-labelledby="loop-presets-dropdown">
+                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 1)">1 <script>document.write(i18n.__('time(s)'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 2)">2 <script>document.write(i18n.__('time(s)'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 3)">3 <script>document.write(i18n.__('time(s)'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 4)">4 <script>document.write(i18n.__('time(s)'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 5)">5 <script>document.write(i18n.__('time(s)'))</script></a>
+                    </div>
+                </div>
                 <div class="dropdown dropleft dropdown-default" id="dropdown-extend">
                     <a class="dropdown-toggle" href="#" role="button" id="dropdown-button-extend"
                        data-toggle="dropdown"
@@ -432,9 +488,7 @@
                 myDate.setSeconds(myDate.getSeconds() + Number(timeCount * 60));
                 $("#to-num-h").html(myDate.getHours());
                 let minuteString = myDate.getMinutes().toString();
-                if (minuteString.length < 2) {
-                    minuteString = "0" + minuteString;
-                }
+                if (minuteString.length < 2) minuteString = "0" + minuteString;
                 $("#to-num-min").html(minuteString);
             }
         }
@@ -446,57 +500,50 @@
         }
 
         function allSet() {
-            function removeRedundantEnd(number) {
-                let result = number.toFixed(2).replaceAll("0", " ").trimEnd().replaceAll(" ", "0");
-                if (result.lastIndexOf(".") === result.length) result = result.replaceAll(".", "");
-                return shi.ArabicNumberTimeParser(isNaN(Number(result)) ? "" : Number(result), {
-                    lang: store.get("i18n").toString().replace("-", "_"),
-                    as: "m",
-                    to: "m",
-                    ignoreError: true
-                });
+            let
+                workTime,
+                restTime,
+                loopCount;
+            if (onlyrest) {
+                restTime = $("#rest-time-onlyrest").val().replace(new RegExp('[' + i18n.__('min') + ']', "g"), "");
+                workTime = 0;
+                loopCount = 1;
+            } else {
+                workTime = $("#work-time").val().replace(new RegExp('[' + i18n.__('min') + ']', "g"), "");
+                restTime = $("#rest-time").val().replace(new RegExp('[' + i18n.__('min') + ']', "g"), "");
+                loopCount = $("#loop").val().replace(new RegExp('[' + i18n.__('times') + ']', "g"), "");
             }
+            if (isNaN(Number(workTime)) || isNaN(Number(restTime)) || isNaN(Number(loopCount)) || (Number(workTime) === 0 && !onlyrest)) {
+                if (!onlyrest)
+                    sumGet((store.get("infinity") || loopCount === "") ? NaN :
+                        Number(workTime) * Number(loopCount) + Number(restTime) * Number(loopCount ? loopCount : 0));
+                else
+                    sumGet(Number(restTime));
+                $("#bottom-btn").attr("disabled", true);
+                $("#next-timer-button").attr("disabled", true);
+            } else {
+                if (!onlyrest)
+                    sumGet((store.get("infinity") || loopCount === "") ? NaN :
+                        Number(workTime) * Number(loopCount) + Number(restTime) * Number(loopCount ? loopCount : 0));
+                else
+                    sumGet(Number(restTime));
+                $("#bottom-btn").attr("disabled", false);
+                $("#next-timer-button").attr("disabled", false);
+            }
+        }
 
-            try {
-                if (onlyrest) {
-                    let restTimeGet = shi.humanTimeParser($("#rest-time-onlyrest").val(), {
-                        as: "m",
-                        to: "m",
-                        ignoreError: true
-                    });
-                    if (!isNaN(restTimeGet))
-                        if (restTimeGet > 0 && restTimeGet <= 1440)
-                            sumGet(restTimeGet);
-                        else allClear();
-                    else allClear();
-                } else {
-                    let timesSingular = i18n.__('times').replace(new RegExp('s(?!\w)', "g"), "");
-                    let workTimeGet = shi.humanTimeParser($("#work-time").val(), {
-                        as: "m",
-                        to: "m",
-                        ignoreError: true
-                    });
-                    let restTimeGet = 0;
-                    if (getBreakPercentage() !== 0) {
-                        restTimeGet = removeRedundantEnd(workTimeGet * getBreakPercentage());
-                        $("#rest-time").val(restTimeGet);
-                    } else
-                        restTimeGet = shi.humanTimeParser($("#rest-time").val(), {
-                            as: "m",
-                            to: "m",
-                            ignoreError: true
-                        });
-                    let loopGet = $("#loop").val().replace(new RegExp(i18n.__('times') + '|' + timesSingular, "g"), "");
-                    if (workTimeGet > 0 && restTimeGet > 0 && workTimeGet <= 1440 && restTimeGet <= 1440 && loopGet >= 1 && loopGet <= 1440 && ((workTimeGet + restTimeGet) * loopGet) && (loopGet == Math.floor(loopGet))) {
-                        sumGet((workTimeGet + restTimeGet) * loopGet);
-                    } else {
-                        allClear();
-                    }
-                    if (store.get("infinity")) infinityMode();
-                }
-            } catch {
-                allClear();
+        function setPresetTime(fieldId, value) {
+            $(`#${fieldId}`).val(value);
+            allSet();
+        }
+
+        function keyDownSubmitter(e) {
+            if (e) {
+                if (e.keyCode !== 13) return;
             }
+            if (store.get("need-confirm")) {
+                if (confirm(i18n.__('submitter-confirm'))) submitter();
+            } else submitter();
         }
 
         function allClear() {

--- a/index.html
+++ b/index.html
@@ -183,12 +183,12 @@
                         <i class="iconfont icon-caret-down onlyRest"></i>
                     </a>
                     <div class="dropdown-menu" aria-labelledby="rest-time-onlyrest-presets-dropdown">
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 3)">3 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 5)">5 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 10)">10 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 15)">15 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 20)">20 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 30)">30 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 3, '3分钟')">3分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 5, '5分钟')">5分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 10, '10分钟')">10分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 15, '15分钟')">15分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 20, '20分钟')">20分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time-onlyrest', 30, '30分钟')">30分钟</a>
                     </div>
                 </div>
                 <br /><br />
@@ -254,17 +254,17 @@
                        required />
                 <div class="dropdown d-inline time-preset-dropdown">
                     <a class="dropdown-toggle" href="#" role="button" id="work-time-presets-dropdown"
-                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-display="static">
                         <i class="iconfont icon-caret-down work"></i>
                     </a>
                     <div class="dropdown-menu" aria-labelledby="work-time-presets-dropdown">
-                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 10)">10 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 20)">20 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 30)">30 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 45)">45 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 60)">60 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 90)">90 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 120)">120 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 10, '10分钟')">10分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 20, '20分钟')">20分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 30, '30分钟')">30分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 45, '45分钟')">45分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 60, '60分钟')">60分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 90, '90分钟')">90分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('work-time', 120, '120分钟')">120分钟</a>
                     </div>
                 </div>
                 <input id="focus-work-set" type="checkbox" onchange="focusNotifier()" />
@@ -277,16 +277,16 @@
                 <input name="rest-time" id="rest-time" type="text" onkeyup="allSet()" class="rest lead" required />
                 <div class="dropdown d-inline time-preset-dropdown">
                     <a class="dropdown-toggle" href="#" role="button" id="rest-time-presets-dropdown"
-                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-display="static">
                         <i class="iconfont icon-caret-down rest"></i>
                     </a>
                     <div class="dropdown-menu" aria-labelledby="rest-time-presets-dropdown">
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 3)">3 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 5)">5 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 10)">10 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 15)">15 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 20)">20 <script>document.write(i18n.__('min'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 30)">30 <script>document.write(i18n.__('min'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 3, '3分钟')">3分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 5, '5分钟')">5分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 10, '10分钟')">10分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 15, '15分钟')">15分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 20, '20分钟')">20分钟</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('rest-time', 30, '30分钟')">30分钟</a>
                     </div>
                 </div>
                 <input id="focus-rest-set" type="checkbox" onchange="focusNotifier()" />
@@ -299,15 +299,15 @@
                 <input name="loop" id="loop" type="text" onkeyup="allSet()" class="small text-muted" required />
                 <div class="dropdown d-inline time-preset-dropdown">
                     <a class="dropdown-toggle" href="#" role="button" id="loop-presets-dropdown"
-                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-display="static">
                         <i class="iconfont icon-caret-down text-muted"></i>
                     </a>
                     <div class="dropdown-menu" aria-labelledby="loop-presets-dropdown">
-                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 1)">1 <script>document.write(i18n.__('time(s)'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 2)">2 <script>document.write(i18n.__('time(s)'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 3)">3 <script>document.write(i18n.__('time(s)'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 4)">4 <script>document.write(i18n.__('time(s)'))</script></a>
-                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 5)">5 <script>document.write(i18n.__('time(s)'))</script></a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 1, '1次')">1次</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 2, '2次')">2次</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 3, '3次')">3次</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 4, '4次')">4次</a>
+                        <a class="dropdown-item" href="javascript:setPresetTime('loop', 5, '5次')">5次</a>
                     </div>
                 </div>
                 <div class="dropdown dropleft dropdown-default" id="dropdown-extend">
@@ -532,8 +532,8 @@
             }
         }
 
-        function setPresetTime(fieldId, value) {
-            $(`#${fieldId}`).val(value);
+        function setPresetTime(fieldId, value, displayValue) {
+            $(`#${fieldId}`).val(displayValue || value);
             allSet();
         }
 

--- a/style.css
+++ b/style.css
@@ -297,6 +297,170 @@ li input:nth-last-child(4)::after {
     line-height: 200%;
 }
 
+.time-preset-dropdown {
+    display: inline-block;
+    position: relative;
+    margin-left: 1px;
+    margin-right: 5px;
+    vertical-align: middle;
+    width: auto;
+}
+
+.time-preset-dropdown .dropdown-toggle {
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    border: none;
+    display: inline-block;
+    vertical-align: middle;
+    line-height: 1;
+}
+
+.time-preset-dropdown .dropdown-toggle::after {
+    display: none;
+}
+
+.time-preset-dropdown .dropdown-toggle i {
+    color: #6c757d;
+    font-size: 14px;
+    vertical-align: middle;
+    position: relative;
+    top: -1px;
+    transition: transform 0.2s ease-in-out;
+}
+
+.time-preset-dropdown .dropdown-toggle[aria-expanded="true"] i {
+    transform: rotate(180deg);
+}
+
+.time-preset-dropdown .dropdown-toggle i.work {
+    color: #ea5454;
+}
+
+.time-preset-dropdown .dropdown-toggle i.rest {
+    color: #5490ea;
+}
+
+.time-preset-dropdown .dropdown-toggle i.onlyRest {
+    color: #a26ae5;
+}
+
+.time-preset-dropdown .dropdown-menu {
+    min-width: 85px;
+    text-align: center;
+    margin-top: 5px;
+    font-size: 14px;
+    z-index: 1030;
+    max-height: 150px;
+    overflow-y: auto;
+    transform: translateX(-166px) !important;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+}
+
+.time-preset-dropdown .dropdown-menu .dropdown-item {
+    padding: 0.25rem 0.5rem;
+    height: 28px;
+    line-height: 1.5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Work dropdown items */
+#work-time-presets-dropdown + .dropdown-menu .dropdown-item {
+    color: #ea5454;
+}
+
+#work-time-presets-dropdown + .dropdown-menu .dropdown-item:hover,
+#work-time-presets-dropdown + .dropdown-menu .dropdown-item:focus {
+    color: #ea5454;
+    background-color: rgba(234, 84, 84, 0.1);
+}
+
+/* Rest dropdown items */
+#rest-time-presets-dropdown + .dropdown-menu .dropdown-item {
+    color: #5490ea;
+}
+
+#rest-time-presets-dropdown + .dropdown-menu .dropdown-item:hover,
+#rest-time-presets-dropdown + .dropdown-menu .dropdown-item:focus {
+    color: #5490ea;
+    background-color: rgba(84, 144, 234, 0.1);
+}
+
+/* Only Rest dropdown items */
+#rest-time-onlyrest-presets-dropdown + .dropdown-menu .dropdown-item {
+    color: #a26ae5;
+}
+
+#rest-time-onlyrest-presets-dropdown + .dropdown-menu .dropdown-item:hover,
+#rest-time-onlyrest-presets-dropdown + .dropdown-menu .dropdown-item:focus {
+    color: #a26ae5;
+    background-color: rgba(162, 106, 229, 0.1);
+}
+
+/* Loop dropdown items hover effect */
+#loop-presets-dropdown + .dropdown-menu .dropdown-item:hover,
+#loop-presets-dropdown + .dropdown-menu .dropdown-item:focus {
+    color: #6c757d;
+    background-color: rgba(108, 117, 125, 0.1);
+}
+
+/* Custom scrollbar for dropdown menus */
+.time-preset-dropdown .dropdown-menu::-webkit-scrollbar {
+    width: 4px;
+}
+
+.time-preset-dropdown .dropdown-menu::-webkit-scrollbar-track {
+    background-color: #fefefe;
+    border-radius: 10px;
+}
+
+.time-preset-dropdown .dropdown-menu::-webkit-scrollbar-thumb {
+    background-color: #6c757d66;
+    border-radius: 10px;
+}
+
+.time-preset-dropdown .dropdown-menu::-webkit-scrollbar-thumb:hover {
+    background-color: #6c757d99;
+}
+
+/* Work dropdown scrollbar */
+#work-time-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb {
+    background-color: rgba(234, 84, 84, 0.4);
+}
+
+#work-time-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(234, 84, 84, 0.6);
+}
+
+/* Rest dropdown scrollbar */
+#rest-time-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb {
+    background-color: rgba(84, 144, 234, 0.4);
+}
+
+#rest-time-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(84, 144, 234, 0.6);
+}
+
+/* OnlyRest dropdown scrollbar */
+#rest-time-onlyrest-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb {
+    background-color: rgba(162, 106, 229, 0.4);
+}
+
+#rest-time-onlyrest-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(162, 106, 229, 0.6);
+}
+
+/* Make dropdown width match input width */
+#work-time-presets-dropdown + .dropdown-menu,
+#rest-time-presets-dropdown + .dropdown-menu,
+#rest-time-onlyrest-presets-dropdown + .dropdown-menu,
+#loop-presets-dropdown + .dropdown-menu {
+    width: 192px;
+}
+
 .time-bar-focus {
     left: auto !important;
     right: auto !important;

--- a/style.css
+++ b/style.css
@@ -292,9 +292,8 @@ li input:nth-last-child(4)::after {
     -webkit-user-select: none;
 }
 
-.dropdown-item {
-    font-size: 12px;
-    line-height: 200%;
+.dropdown-menu.show {
+    display: block;
 }
 
 .time-preset-dropdown {
@@ -348,14 +347,16 @@ li input:nth-last-child(4)::after {
 .time-preset-dropdown .dropdown-menu {
     min-width: 85px;
     text-align: center;
-    margin-top: 5px;
+    margin-top: 0;
     font-size: 14px;
-    z-index: 1030;
-    max-height: 150px;
+    z-index: 1500;
+    max-height: 84px; /* Height for 3 items (28px per item) */
     overflow-y: auto;
-    transform: translateX(-166px) !important;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    border-radius: 4px;
+    padding: 5px 0;
+    position: absolute;
+    top: 100%;
+    left: auto;
+    right: auto;
 }
 
 .time-preset-dropdown .dropdown-menu .dropdown-item {
@@ -365,11 +366,56 @@ li input:nth-last-child(4)::after {
     display: flex;
     align-items: center;
     justify-content: center;
+    text-align: center;
+    font-weight: normal;
+    background-color: white !important;
+    background: white !important;
+    opacity: 1 !important;
 }
 
-/* Work dropdown items */
+.align-content-center {
+    position: relative;
+    text-align: center;
+}
+
+#work-time-presets-dropdown + .dropdown-menu,
+#rest-time-presets-dropdown + .dropdown-menu,
+#rest-time-onlyrest-presets-dropdown + .dropdown-menu,
+#loop-presets-dropdown + .dropdown-menu {
+    width: 192px;
+    min-width: 192px;
+    background-color: white !important;
+    background: white !important;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 4px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    position: absolute;
+    transform: translateX(-173px);
+    z-index: 1500;
+    opacity: 1 !important;
+    margin-top: 5px;
+    left: 0;
+    top: 100%;
+}
+
+#work-time-presets-dropdown + .dropdown-menu .dropdown-item,
+#rest-time-presets-dropdown + .dropdown-menu .dropdown-item,
+#rest-time-onlyrest-presets-dropdown + .dropdown-menu .dropdown-item,
+#loop-presets-dropdown + .dropdown-menu .dropdown-item {
+    background-color: white;
+    background: white;
+    opacity: 1;
+}
+
+.dropdown-item {
+    font-size: 12px;
+    line-height: 200%;
+    background-color: white;
+}
+
 #work-time-presets-dropdown + .dropdown-menu .dropdown-item {
     color: #ea5454;
+    background-color: white;
 }
 
 #work-time-presets-dropdown + .dropdown-menu .dropdown-item:hover,
@@ -378,9 +424,9 @@ li input:nth-last-child(4)::after {
     background-color: rgba(234, 84, 84, 0.1);
 }
 
-/* Rest dropdown items */
 #rest-time-presets-dropdown + .dropdown-menu .dropdown-item {
     color: #5490ea;
+    background-color: white;
 }
 
 #rest-time-presets-dropdown + .dropdown-menu .dropdown-item:hover,
@@ -389,9 +435,9 @@ li input:nth-last-child(4)::after {
     background-color: rgba(84, 144, 234, 0.1);
 }
 
-/* Only Rest dropdown items */
 #rest-time-onlyrest-presets-dropdown + .dropdown-menu .dropdown-item {
     color: #a26ae5;
+    background-color: white;
 }
 
 #rest-time-onlyrest-presets-dropdown + .dropdown-menu .dropdown-item:hover,
@@ -400,65 +446,15 @@ li input:nth-last-child(4)::after {
     background-color: rgba(162, 106, 229, 0.1);
 }
 
-/* Loop dropdown items hover effect */
+#loop-presets-dropdown + .dropdown-menu .dropdown-item {
+    color: #6c757d;
+    background-color: white;
+}
+
 #loop-presets-dropdown + .dropdown-menu .dropdown-item:hover,
 #loop-presets-dropdown + .dropdown-menu .dropdown-item:focus {
     color: #6c757d;
     background-color: rgba(108, 117, 125, 0.1);
-}
-
-/* Custom scrollbar for dropdown menus */
-.time-preset-dropdown .dropdown-menu::-webkit-scrollbar {
-    width: 4px;
-}
-
-.time-preset-dropdown .dropdown-menu::-webkit-scrollbar-track {
-    background-color: #fefefe;
-    border-radius: 10px;
-}
-
-.time-preset-dropdown .dropdown-menu::-webkit-scrollbar-thumb {
-    background-color: #6c757d66;
-    border-radius: 10px;
-}
-
-.time-preset-dropdown .dropdown-menu::-webkit-scrollbar-thumb:hover {
-    background-color: #6c757d99;
-}
-
-/* Work dropdown scrollbar */
-#work-time-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb {
-    background-color: rgba(234, 84, 84, 0.4);
-}
-
-#work-time-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb:hover {
-    background-color: rgba(234, 84, 84, 0.6);
-}
-
-/* Rest dropdown scrollbar */
-#rest-time-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb {
-    background-color: rgba(84, 144, 234, 0.4);
-}
-
-#rest-time-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb:hover {
-    background-color: rgba(84, 144, 234, 0.6);
-}
-
-/* OnlyRest dropdown scrollbar */
-#rest-time-onlyrest-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb {
-    background-color: rgba(162, 106, 229, 0.4);
-}
-
-#rest-time-onlyrest-presets-dropdown + .dropdown-menu::-webkit-scrollbar-thumb:hover {
-    background-color: rgba(162, 106, 229, 0.6);
-}
-
-/* Make dropdown width match input width */
-#work-time-presets-dropdown + .dropdown-menu,
-#rest-time-presets-dropdown + .dropdown-menu,
-#rest-time-onlyrest-presets-dropdown + .dropdown-menu,
-#loop-presets-dropdown + .dropdown-menu {
-    width: 192px;
 }
 
 .time-bar-focus {
@@ -581,8 +577,9 @@ li input:nth-last-child(4)::after {
 }
 
 #set .dropdown-menu {
-    margin-top: 6px;
-    transform: translateY(50px) !important;
+    margin-top: 5px;
+    transform: translateY(0px) !important;
+    transform: translateX(-191px) !important;
 }
 
 #set #dropdown-menu-extend {
@@ -1193,4 +1190,23 @@ li input:nth-last-child(4)::after {
 
 .hotkey-set-label {
     padding-top: 0 !important;
+}
+
+/* Position dropdown menus properly */
+.dropdown-menu.show {
+    display: block;
+}
+
+.time-preset-dropdown .dropdown-menu .dropdown-item {
+    padding: 0.25rem 0.5rem;
+    height: 28px;
+    line-height: 1.5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-weight: normal;
+    background-color: white !important;
+    background: white !important;
+    opacity: 1 !important;
 }


### PR DESCRIPTION
# Add preset time dropdowns for work, rest, and loop durations
<img width="342" alt="截屏2025-04-20 21 00 33" src="https://github.com/user-attachments/assets/98fbd0d7-d759-4320-9afe-8b854af948c6" />

## Overview
This PR introduces a new user interface improvement to wnr that allows users to quickly select common time durations through dropdown menus with a scrollable interface, rather than manually typing values each time.

## Features
- Added preset time dropdowns for work sessions, rest sessions, and loop counts
- Implemented a scrollable dropdown menu for better UX when many presets are available
- Styled dropdowns to match the existing application design language
- Color-coded dropdowns to match their respective functions (work=red, rest=blue, onlyRest=purple)
- Added hover effects for better visual feedback

## UI Changes
- Small dropdown toggle buttons next to time input fields
- Dropdown menus appear on click with preset time values
- Scrollable dropdown menus that can accommodate multiple options
- Consistent styling with the rest of the application