### PR TITLE
Fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ yarn appimage # linux AppImage
 ## Star History
 
 <p align="center">
-    <a href="https://star-history.com/#RoderickQiu/wnr&Date">
+    <a href="https://star-history.dera.page/#RoderickQiu/wnr&Date">
      <picture>
-       <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=RoderickQiu/wnr&type=Date&theme=dark" />
-       <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=RoderickQiu/wnr&type=Date" />
-       <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=RoderickQiu/wnr&type=Date" />
+       <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RoderickQiu/wnr&type=Date&theme=dark" />
+       <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RoderickQiu/wnr&type=Date" />
+       <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RoderickQiu/wnr&type=Date" />
      </picture>
     </a>
 </p>


### PR DESCRIPTION
The star history chart in the README has been broken for a while: it depends on the GitHub stargazer API, which now restricts access without a token, so the chart fails to render. This change points the chart at a working star history service so it displays as expected again.